### PR TITLE
feat: Supabase Auth with multi-user login and per-user data isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .env
 .supabase/
 test-results/
+*.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,13 @@ Also early-stage startups who need a simple CRM with AI capture built in from da
 
 \## Product status
 
-Very early stage — concept and scaffold. Treat every session as greenfield. 
+Early stage. Confirm what exists before building anything new.
 
-Confirm what exists before building anything new.
+What has been built:
+
+\- Supabase Auth (email/password sign-up and sign-in, per-user RLS on crm_store)
+\- Lightweight built-in CRM (contacts, pipeline, activity log, AI Radar, reminders, voice notes)
+\- AI voice note processing via Claude API (`/api/ai`)
 
 
 
@@ -155,7 +159,7 @@ When asked to log something as a backlog item, create a GitHub Issue.
 
 \- Add npm packages without checking first
 
-\- Modify Supabase schema without showing the migration file first
+\- Modify Supabase schema without showing the migration file first (migrations are NOT auto-applied — the user must paste them into Database → SQL Editor in the Supabase dashboard manually)
 
 \- Push directly to main
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,23 @@ Built-in lightweight CRM available for users without an existing CRM.
 
 
 
+\## Local development environment
+
+Two separate file systems are in play:
+
+\- Claude Code runs in Linux/WSL at `/home/user/nimblecrm`
+\- The dev server runs from Windows PowerShell at `C:\Users\davie\Projects\nimblecrm`
+
+These are not the same files. After making changes, the user must pull them into the Windows copy before testing:
+
+```powershell
+git pull origin <branch>
+```
+
+Then restart the dev server (`npm run dev`) to pick up the changes.
+
+Do not tell the user to edit files directly or clear caches until after they have pulled the latest changes.
+
 \## Backlog
 
 Managed in GitHub Issues: https://github.com/nimbleworx/nimblecrm/issues

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -26,7 +26,11 @@ export default function LoginPage() {
         router.replace("/");
       }
     } else {
-      const { error } = await supabase.auth.signUp({ email, password });
+      const { error } = await supabase.auth.signUp({
+        email,
+        password,
+        options: { emailRedirectTo: `${window.location.origin}/login` },
+      });
       if (error) {
         setError(error.message);
       } else {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,115 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { supabase } from "@/lib/supabase";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [mode, setMode] = useState<"login" | "signup">("login");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setMessage("");
+    setLoading(true);
+
+    if (mode === "login") {
+      const { error } = await supabase.auth.signInWithPassword({ email, password });
+      if (error) {
+        setError(error.message);
+      } else {
+        router.replace("/");
+      }
+    } else {
+      const { error } = await supabase.auth.signUp({ email, password });
+      if (error) {
+        setError(error.message);
+      } else {
+        setMessage("Check your email to confirm your account, then sign in.");
+        setMode("login");
+      }
+    }
+
+    setLoading(false);
+  };
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#020817", display: "flex", alignItems: "center", justifyContent: "center", fontFamily: "'Plus Jakarta Sans', 'Segoe UI', sans-serif" }}>
+      <div style={{ width: "100%", maxWidth: 400, padding: "0 20px" }}>
+        <div style={{ textAlign: "center", marginBottom: 32 }}>
+          <div style={{ fontSize: 24, fontWeight: 800, color: "#fff", letterSpacing: "-0.5px" }}>⚡ NimbleCRM</div>
+          <div style={{ fontSize: 11, color: "#334155", letterSpacing: "1px", marginTop: 4 }}>AI-POWERED BY NIMBLEWORX</div>
+        </div>
+
+        <div style={{ background: "#0F172A", border: "1px solid #1E293B", borderRadius: 14, padding: "28px 24px", boxShadow: "0 24px 60px #00000099" }}>
+          <div style={{ fontSize: 17, fontWeight: 700, color: "#E2E8F0", marginBottom: 22 }}>
+            {mode === "login" ? "Sign in to your account" : "Create your account"}
+          </div>
+
+          {message && (
+            <div style={{ background: "#14532D22", border: "1px solid #22C55E44", borderRadius: 8, padding: "10px 14px", color: "#22C55E", fontSize: 13, marginBottom: 16 }}>
+              {message}
+            </div>
+          )}
+
+          {error && (
+            <div style={{ background: "#7F1D1D22", border: "1px solid #EF444444", borderRadius: 8, padding: "10px 14px", color: "#EF4444", fontSize: 13, marginBottom: 16 }}>
+              {error}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit}>
+            <div style={{ marginBottom: 14 }}>
+              <div style={{ fontSize: 11, color: "#64748B", fontWeight: 600, marginBottom: 5, letterSpacing: "0.5px" }}>EMAIL</div>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@company.com"
+                required
+                style={{ width: "100%", background: "#1E293B", border: "1px solid #334155", borderRadius: 8, padding: "9px 12px", color: "#E2E8F0", fontSize: 13, outline: "none", boxSizing: "border-box" }}
+              />
+            </div>
+
+            <div style={{ marginBottom: 22 }}>
+              <div style={{ fontSize: 11, color: "#64748B", fontWeight: 600, marginBottom: 5, letterSpacing: "0.5px" }}>PASSWORD</div>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder={mode === "signup" ? "Min 6 characters" : "••••••••"}
+                required
+                style={{ width: "100%", background: "#1E293B", border: "1px solid #334155", borderRadius: 8, padding: "9px 12px", color: "#E2E8F0", fontSize: 13, outline: "none", boxSizing: "border-box" }}
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={loading}
+              style={{ width: "100%", background: "#3B82F6", color: "#fff", border: "none", borderRadius: 8, padding: "11px 18px", fontSize: 14, fontWeight: 600, cursor: loading ? "default" : "pointer", opacity: loading ? 0.6 : 1 }}
+            >
+              {loading ? "Please wait…" : mode === "login" ? "Sign in" : "Create account"}
+            </button>
+          </form>
+
+          <div style={{ textAlign: "center", marginTop: 18, fontSize: 13, color: "#64748B" }}>
+            {mode === "login" ? (
+              <>Don&apos;t have an account?{" "}
+                <button onClick={() => { setMode("signup"); setError(""); setMessage(""); }} style={{ background: "none", border: "none", color: "#3B82F6", cursor: "pointer", fontSize: 13, fontWeight: 600, padding: 0 }}>Sign up</button>
+              </>
+            ) : (
+              <>Already have an account?{" "}
+                <button onClick={() => { setMode("login"); setError(""); setMessage(""); }} style={{ background: "none", border: "none", color: "#3B82F6", cursor: "pointer", fontSize: 13, fontWeight: 600, padding: 0 }}>Sign in</button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,44 @@
 "use client";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import type { User } from "@supabase/supabase-js";
+import { supabase } from "@/lib/supabase";
 import CRM from "@/components/CRM";
 
 export default function Home() {
-  return <CRM />;
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session?.user) {
+        setUser(session.user);
+      } else {
+        router.replace("/login");
+      }
+      setLoading(false);
+    });
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session?.user) {
+        setUser(session.user);
+      } else {
+        setUser(null);
+        router.replace("/login");
+      }
+    });
+
+    return () => subscription.unsubscribe();
+  }, [router]);
+
+  if (loading || !user) {
+    return (
+      <div style={{ minHeight: "100vh", background: "#020817", display: "flex", alignItems: "center", justifyContent: "center", color: "#64748B", fontFamily: "system-ui" }}>
+        Loading…
+      </div>
+    );
+  }
+
+  return <CRM user={user} />;
 }

--- a/src/components/CRM.tsx
+++ b/src/components/CRM.tsx
@@ -3,14 +3,12 @@ import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabase";
 
 // ── Supabase persistence helpers ──────────────────────────────────────────────
-const USER_ID = "default"; // Replace with auth.user.id once you add Supabase Auth
-
-const load = async (key: string, fallback: any) => {
+const load = async (userId: string, key: string, fallback: any) => {
   try {
     const { data } = await supabase
       .from("crm_store")
       .select("value")
-      .eq("user_id", USER_ID)
+      .eq("user_id", userId)
       .eq("key", key)
       .single();
     return data ? JSON.parse(data.value) : fallback;
@@ -19,10 +17,10 @@ const load = async (key: string, fallback: any) => {
   }
 };
 
-const save = async (key: string, val: any) => {
+const save = async (userId: string, key: string, val: any) => {
   try {
     await supabase.from("crm_store").upsert(
-      { user_id: USER_ID, key, value: JSON.stringify(val) },
+      { user_id: userId, key, value: JSON.stringify(val) },
       { onConflict: "user_id,key" }
     );
   } catch {}
@@ -191,7 +189,7 @@ const avatarColor = (name: string) => {
 };
 
 // ── Main CRM Component ────────────────────────────────────────────────────────
-export default function CRM() {
+export default function CRM({ user }: { user: { id: string; email?: string } }) {
   const [contacts, setContacts] = useState<any[]>([]);
   const [deals, setDeals] = useState<any[]>([]);
   const [activities, setActivities] = useState<any[]>([]);
@@ -209,24 +207,24 @@ export default function CRM() {
 
   useEffect(() => {
     (async () => {
-      const c = await load("contacts", SEED_CONTACTS);
-      const d = await load("deals", SEED_DEALS);
-      const a = await load("activities", SEED_ACTIVITIES);
-      const r = await load("reminders", SEED_REMINDERS);
-      const dis = await load("dismissed", []);
-      const proc = await load("processedComms", []);
+      const c = await load(user.id, "contacts", SEED_CONTACTS);
+      const d = await load(user.id, "deals", SEED_DEALS);
+      const a = await load(user.id, "activities", SEED_ACTIVITIES);
+      const r = await load(user.id, "reminders", SEED_REMINDERS);
+      const dis = await load(user.id, "dismissed", []);
+      const proc = await load(user.id, "processedComms", []);
       setContacts(c); setDeals(d); setActivities(a); setReminders(r);
       setDismissed(dis); setProcessedComms(proc);
       setLoaded(true);
     })();
   }, []);
 
-  useEffect(() => { if (loaded) save("contacts", contacts); }, [contacts, loaded]);
-  useEffect(() => { if (loaded) save("deals", deals); }, [deals, loaded]);
-  useEffect(() => { if (loaded) save("activities", activities); }, [activities, loaded]);
-  useEffect(() => { if (loaded) save("reminders", reminders); }, [reminders, loaded]);
-  useEffect(() => { if (loaded) save("dismissed", dismissed); }, [dismissed, loaded]);
-  useEffect(() => { if (loaded) save("processedComms", processedComms); }, [processedComms, loaded]);
+  useEffect(() => { if (loaded) save(user.id, "contacts", contacts); }, [contacts, loaded, user.id]);
+  useEffect(() => { if (loaded) save(user.id, "deals", deals); }, [deals, loaded, user.id]);
+  useEffect(() => { if (loaded) save(user.id, "activities", activities); }, [activities, loaded, user.id]);
+  useEffect(() => { if (loaded) save(user.id, "reminders", reminders); }, [reminders, loaded, user.id]);
+  useEffect(() => { if (loaded) save(user.id, "dismissed", dismissed); }, [dismissed, loaded, user.id]);
+  useEffect(() => { if (loaded) save(user.id, "processedComms", processedComms); }, [processedComms, loaded, user.id]);
 
   const nudges = generateNudges(contacts, deals, activities, reminders).filter((n) => !dismissed.includes(n.id));
   const pendingIncoming = SIMULATED_COMMS.filter((c) => !processedComms.includes(c.id));
@@ -343,7 +341,11 @@ Extract and return JSON with these fields:
           <div style={{ fontSize: 10, color: "#334155", letterSpacing: "1px", marginBottom: 10 }}>QUICK STATS</div>
           <div style={{ fontSize: 12, color: "#64748B", marginBottom: 6 }}>Pipeline <span style={{ color: "#60A5FA", float: "right" }}>{fmt(pipelineTotal)}</span></div>
           <div style={{ fontSize: 12, color: "#64748B", marginBottom: 6 }}>Won <span style={{ color: "#22C55E", float: "right" }}>{fmt(wonTotal)}</span></div>
-          <div style={{ fontSize: 12, color: "#64748B" }}>Contacts <span style={{ color: "#E2E8F0", float: "right" }}>{contacts.length}</span></div>
+          <div style={{ fontSize: 12, color: "#64748B", marginBottom: 14 }}>Contacts <span style={{ color: "#E2E8F0", float: "right" }}>{contacts.length}</span></div>
+          <div style={{ fontSize: 11, color: "#475569", marginBottom: 8, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{user.email}</div>
+          <button onClick={() => supabase.auth.signOut()} style={{ width: "100%", background: "none", border: "1px solid #334155", borderRadius: 8, padding: "7px 12px", color: "#64748B", fontSize: 12, cursor: "pointer", fontWeight: 500 }}>
+            Sign out
+          </button>
         </div>
       </div>
 

--- a/supabase/migrations/20260329000001_auth_rls.sql
+++ b/supabase/migrations/20260329000001_auth_rls.sql
@@ -1,0 +1,10 @@
+-- Replace the permissive open policy with per-user RLS scoped to auth.uid()
+
+drop policy if exists "Allow all for default user" on crm_store;
+
+-- Each user can only read and write their own rows
+create policy "Users can manage their own data"
+  on crm_store
+  for all
+  using (auth.uid()::text = user_id)
+  with check (auth.uid()::text = user_id);

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+const TEST_EMAIL = `test+${Date.now()}@example.com`;
+const TEST_PASSWORD = 'testpassword123';
+
+test('unauthenticated user is redirected to login', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  await expect(page).toHaveURL(/\/login/);
+});
+
+test('login page renders sign in form', async ({ page }) => {
+  await page.goto('http://localhost:3000/login');
+  await expect(page.getByText('Sign in to your account')).toBeVisible();
+  await expect(page.getByPlaceholder('you@company.com')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible();
+});
+
+test('login page toggles to sign up mode', async ({ page }) => {
+  await page.goto('http://localhost:3000/login');
+  await page.getByRole('button', { name: 'Sign up' }).click();
+  await expect(page.getByText('Create your account')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Create account' })).toBeVisible();
+});
+
+test('login shows error for invalid credentials', async ({ page }) => {
+  await page.goto('http://localhost:3000/login');
+  await page.getByPlaceholder('you@company.com').fill('invalid@example.com');
+  await page.getByPlaceholder('••••••••').fill('wrongpassword');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page.locator('text=Invalid').or(page.locator('text=invalid')).or(page.locator('text=credentials')).or(page.locator('text=Email not confirmed'))).toBeVisible({ timeout: 5000 });
+});


### PR DESCRIPTION
## Summary

- Add email/password login and sign-up at `/login`
- Redirect unauthenticated users from `/` to `/login`
- Pass authenticated user into CRM component — replaces hardcoded `user_id = "default"` with `auth.uid()`
- Add sign out button and user email to sidebar footer
- Fix confirmation email redirect to point back to NimbleCRM (not AgentForge)
- Replace open RLS policy with `auth.uid()`-scoped policy so each user sees only their own data
- Document dual filesystem dev environment in CLAUDE.md

## Supabase migration required

Before this is usable in production, run the following in **Database → SQL Editor**:

```sql
drop policy if exists "Allow all for default user" on crm_store;

create policy "Users can manage their own data"
  on crm_store
  for all
  using (auth.uid()::text = user_id)
  with check (auth.uid()::text = user_id);
```

_(Already run in the shared Supabase project.)_

## Pre-merge checklist

- [ ] Vercel env vars set (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`)
- [ ] Production NimbleCRM URL added to Supabase → Authentication → Redirect URLs
- [ ] CI passes

## Test plan

- [ ] `/` redirects to `/login` when unauthenticated
- [ ] Sign up creates a new user and sends confirmation email to NimbleCRM (not AgentForge)
- [ ] Sign in lands on CRM with user email and sign out button visible
- [ ] Sign out returns to `/login`
- [ ] Two different users cannot see each other's data

https://claude.ai/code/session_01MYCEBinuGMJ61MsZ2a75ix